### PR TITLE
Resolve Syntax Between Folk Shards Through Shared Umbrella Target

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,6 @@
 try-import %workspace%/.ci.bazelrc
 try-import %workspace%/.user.bazelrc
 
-build --define=ij_product=intellij-2025.2
 build --java_language_version=17 --java_runtime_version=17
 build --tool_java_language_version=17 --tool_java_runtime_version=17
 

--- a/server/server/src/main/kotlin/org/jetbrains/bazel/server/dependencygraph/DependencyGraph.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bazel/server/dependencygraph/DependencyGraph.kt
@@ -30,6 +30,20 @@ class DependencyGraph(private val rootTargets: Set<Label> = emptySet(), private 
 
   fun getReverseDependencies(id: Label): Set<Label> = idToReverseDependenciesIds[id].orEmpty()
 
+  /**
+   * Gets source files from reverse dependencies (umbrella targets) that contain Java/Kotlin sources.
+   * This is useful for sharded libraries where each shard needs to see sources from umbrella targets
+   * that depend on all shards.
+   */
+  fun getSourcesFromReverseDependencies(targetId: Label): Set<TargetInfo> {
+    return getReverseDependencies(targetId)
+      .mapNotNull { reverseDep -> idToTargetInfo[reverseDep] }
+      .filter { it.hasJvmTargetInfo() }
+      .toSet()
+  }
+
+  fun getTargetInfo(targetId: Label): TargetInfo? = idToTargetInfo[targetId]
+
   private fun createIdToLazyTransitiveDependenciesMap(idToTargetInfo: Map<Label, TargetInfo>): Map<Label, Lazy<Set<TargetInfo>>> =
     idToTargetInfo.mapValues { (_, targetInfo) ->
       calculateLazyTransitiveDependenciesForTarget(targetInfo)

--- a/versions.bzl
+++ b/versions.bzl
@@ -1,6 +1,6 @@
 """Release versions of plugins. The file is swaped with versions.bzl on CI during release"""
 
-INTELLIJ_BAZEL_VERSION = "2025.1.13"
+INTELLIJ_BAZEL_VERSION = "2025.1.13-sf1"
 
 PLATFORM_VERSION = "251"
 SINCE_VERSION = "251.23774.435"


### PR DESCRIPTION
This solution reads shared parent target for targets marked as shard, and put other folk shards under the same umbrella as logical dependencies in at map to project step. This is after loading aspect to kotlin and collecting modules to include, so it wouldn't impact the aspect build process and the BFS process to load project targets.

The updated dependency field flows to plugin client side with existing BSP API connection; at final syntax resolution in IDE internal structure; added visited back tracing as all folk shards are logically interdepend and can create loops in original DAG graph. Back-tracing in DFS is cheap.