### PR TITLE
Force binary run locally for debugging actions

### DIFF
--- a/server/server/src/main/kotlin/org/jetbrains/bazel/server/sync/DebugHelper.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bazel/server/sync/DebugHelper.kt
@@ -27,5 +27,12 @@ object DebugHelper {
       else -> emptyList()
     }
 
+  /**
+   * Common Bazel options we want to apply for any debug execution (run or test).
+   * Currently forces local test strategy to make debugging reliable.
+   */
+  fun commonDebugBazelOptions(debugType: DebugType?): List<String> =
+    if (debugType != null) listOf("--strategy=TestRunner=standalone") else emptyList()
+
   fun buildBeforeRun(debugType: DebugType?): Boolean = debugType !is DebugType.GoDlv
 }

--- a/server/server/src/main/kotlin/org/jetbrains/bazel/server/sync/ExecuteService.kt
+++ b/server/server/src/main/kotlin/org/jetbrains/bazel/server/sync/ExecuteService.kt
@@ -20,6 +20,7 @@ import org.jetbrains.bazel.server.diagnostics.DiagnosticsService
 import org.jetbrains.bazel.server.sync.DebugHelper.buildBeforeRun
 import org.jetbrains.bazel.server.sync.DebugHelper.generateRunArguments
 import org.jetbrains.bazel.server.sync.DebugHelper.generateRunOptions
+import org.jetbrains.bazel.server.sync.DebugHelper.commonDebugBazelOptions
 import org.jetbrains.bazel.workspacecontext.TargetsSpec
 import org.jetbrains.bazel.workspacecontext.provider.WorkspaceContextProvider
 import org.jetbrains.bsp.protocol.AnalysisDebugParams
@@ -89,7 +90,7 @@ class ExecuteService(
   suspend fun runWithDebug(params: RunWithDebugParams): RunResult {
     val requestedDebugType = params.debug
     val debugArguments = generateRunArguments(requestedDebugType)
-    val debugOptions = generateRunOptions(requestedDebugType)
+    val debugOptions = generateRunOptions(requestedDebugType) + commonDebugBazelOptions(requestedDebugType)
     val buildBeforeRun = buildBeforeRun(requestedDebugType)
 
     return runImpl(params.runParams, debugArguments, debugOptions, buildBeforeRun)
@@ -179,6 +180,9 @@ class ExecuteService(
         ),
       )
     }
+
+    // Add common debug bazel options (e.g., force local test execution)
+    commonDebugBazelOptions(debugType).forEach { command.options.add(it) }
 
     params.additionalBazelParams?.let { additionalParams ->
       (command as HasAdditionalBazelOptions).additionalBazelOptions.addAll(additionalParams.split(" "))


### PR DESCRIPTION
Title, otherwise debugger won't attach for obvious reasons