### PR TITLE
Expose AddFileToModuleAction to RightClick menu

### DIFF
--- a/plugin-bazel/src/main/jps-resources/META-INF/plugin.xml
+++ b/plugin-bazel/src/main/jps-resources/META-INF/plugin.xml
@@ -936,6 +936,12 @@
             class="org.jetbrains.bazel.action.registered.OpenProjectViewAction">
     </action>
 
+    <action id="Bazel.AddFileToModuleAction"
+            class="org.jetbrains.bazel.action.registered.AddFileToModuleAction">
+      <add-to-group group-id="EditorPopupMenu" anchor="last"/>
+      <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
+    </action>
+
     <group id="Bazel.ModifyProjectViewDirectories">
       <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
       <reference id="Bazel.AddToProjectViewDirectoriesAction"/>

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/action/registered/AddFileToModuleAction.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/action/registered/AddFileToModuleAction.kt
@@ -1,0 +1,102 @@
+package org.jetbrains.bazel.action.registered
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.components.serviceAsync
+import com.intellij.openapi.project.Project
+import com.intellij.platform.backend.workspace.WorkspaceModel
+import com.intellij.platform.backend.workspace.toVirtualFileUrl
+import com.intellij.platform.ide.progress.withBackgroundProgress
+import com.intellij.platform.util.progress.reportSequentialProgress
+import com.intellij.platform.workspace.storage.MutableEntityStorage
+import com.intellij.workspaceModel.ide.toPath
+import org.jetbrains.bazel.action.SuspendableAction
+import org.jetbrains.bazel.assets.BazelPluginIcons
+import org.jetbrains.bazel.config.BazelPluginBundle
+import org.jetbrains.bazel.config.isBazelProject
+import org.jetbrains.bazel.sync.status.isSyncInProgress
+import org.jetbrains.bazel.utils.isSourceFile
+import org.jetbrains.bazel.workspace.askForInverseSources
+import org.jetbrains.bazel.workspace.getModulesForFile
+import org.jetbrains.bazel.workspace.addToModule
+import org.jetbrains.bazel.workspace.toModuleEntity
+import org.jetbrains.bazel.target.targetUtils
+import org.jetbrains.bazel.sdkcompat.workspacemodel.entities.BazelDummyEntitySource
+import org.jetbrains.bazel.target.moduleEntity
+
+class AddFileToModuleAction :
+  SuspendableAction({ BazelPluginBundle.message("add.file.to.module.action.text") }, BazelPluginIcons.bazel) {
+
+  override suspend fun actionPerformed(project: Project, e: AnActionEvent) {
+    val virtualFile = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
+
+    val workspaceModel = project.serviceAsync<WorkspaceModel>()
+    val entityStorageDiff = MutableEntityStorage.from(workspaceModel.currentSnapshot)
+
+    withBackgroundProgress(project, BazelPluginBundle.message("add.file.to.module.action.progress", virtualFile.name)) {
+      reportSequentialProgress { reporter ->
+        // Get existing modules for the file
+        val existingModules = getModulesForFile(virtualFile, project)
+          .filter { it.moduleEntity?.entitySource != BazelDummyEntitySource }
+          .mapNotNull { it.moduleEntity }
+
+        val url = virtualFile.toVirtualFileUrl(workspaceModel.getVirtualFileUrlManager())
+        val path = url.toPath()
+
+        // Query Bazel for targets that should contain this file
+        val targets = reporter.nextStep(
+          endFraction = 80,
+          text = BazelPluginBundle.message("file.change.processing.step.query"),
+        ) {
+          try {
+            askForInverseSources(project, url).targets.toList()
+          } catch (ex: Exception) {
+            emptyList() // If query fails, return empty list
+          }
+        }
+
+        if (targets.isNotEmpty()) {
+          // Convert targets to module entities and add the file
+          val modules = targets.mapNotNull { it.toModuleEntity(workspaceModel.currentSnapshot, project) }
+
+          for (module in modules) {
+            val alreadyAdded = existingModules.contains(module)
+            if (!alreadyAdded) {
+              url.addToModule(entityStorageDiff, module, virtualFile.extension)
+            }
+          }
+
+          // Update the target utils mapping
+          project.targetUtils.addFileToTargetIdEntry(path, targets)
+
+          reporter.nextStep(endFraction = 100, text = BazelPluginBundle.message("file.change.processing.step.commit")) {
+            // Apply changes to workspace model
+            workspaceModel.update("Add file to module (Bazel)") {
+              it.applyChangesFrom(entityStorageDiff)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  override fun update(project: Project, e: AnActionEvent) {
+    val virtualFile = e.getData(CommonDataKeys.VIRTUAL_FILE)
+
+    // Show action only for Bazel projects, source files, and when sync is not in progress
+    val isVisible = project.isBazelProject &&
+                   virtualFile != null &&
+                   !virtualFile.isDirectory &&
+                   virtualFile.isSourceFile()
+
+    val isEnabled = isVisible && !project.isSyncInProgress()
+
+    e.presentation.isVisible = isVisible
+    e.presentation.isEnabled = isEnabled
+
+    // Update text based on file
+    if (virtualFile != null) {
+      e.presentation.text = BazelPluginBundle.message("add.file.to.module.action.text.with.file", virtualFile.name)
+    }
+  }
+}

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/action/registered/BUILD
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/action/registered/BUILD
@@ -8,6 +8,8 @@ kt_jvm_library(
     ]),
     visibility = ["//plugin-bazel:__subpackages__"],
     deps = [
+        "//commons/src/main/kotlin/org/jetbrains/bazel/label",
+        "//plugin-bazel/src/main/kotlin/org/jetbrains/bazel/target",
         "//plugin-bazel/src/main/kotlin/org/jetbrains/bazel/action",
         "//plugin-bazel/src/main/kotlin/org/jetbrains/bazel/config",
         "//plugin-bazel/src/main/kotlin/org/jetbrains/bazel/languages/projectview",

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/workspace/AssignFileToModuleListener.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/workspace/AssignFileToModuleListener.kt
@@ -346,18 +346,18 @@ private suspend fun queryTargetsForFile(project: Project, fileUrl: VirtualFileUr
     null
   }
 
-private suspend fun askForInverseSources(project: Project, fileUrl: VirtualFileUrl): InverseSourcesResult =
+public suspend fun askForInverseSources(project: Project, fileUrl: VirtualFileUrl): InverseSourcesResult =
   project.connection.runWithServer { bspServer ->
     bspServer
       .buildTargetInverseSources(InverseSourcesParams(TextDocumentIdentifier(fileUrl.toPath())))
   }
 
-private fun Label.toModuleEntity(storage: ImmutableEntityStorage, project: Project): ModuleEntity? {
+fun Label.toModuleEntity(storage: ImmutableEntityStorage, project: Project): ModuleEntity? {
   val moduleId = ModuleId(this.formatAsModuleName(project))
   return storage.resolve(moduleId)
 }
 
-private fun VirtualFileUrl.addToModule(
+fun VirtualFileUrl.addToModule(
   entityStorageDiff: MutableEntityStorage,
   module: ModuleEntity,
   extension: String?,

--- a/plugin-bazel/src/main/resources/messages/BazelPluginBundle.properties
+++ b/plugin-bazel/src/main/resources/messages/BazelPluginBundle.properties
@@ -13,6 +13,11 @@ action.run.all.tests.under.with.coverage=Run all tests under {0} with Coverage
 action.run.all.tests.under=Run all tests under {0}
 action.run.all.tests.with.coverage=Run all tests with Coverage
 action.run.all.tests=Run all tests
+# The sync actions below do not support syncing new targets that were not part of the previous sync
+# To sync new targets, use the "Resync project" action instead
+add.file.to.module.action.text=Sync File
+add.file.to.module.action.text.with.file=Sync "{0}"
+add.file.to.module.action.progress=Syncing "{0}"
 advanced.settings.display.name=Advanced Settings
 annotation.bazelrc.deprecated.flag=Flag: {0} is deprecated
 annotation.bazelrc.flag.not.applicable=Flag: {0} is not applicable to command {1}


### PR DESCRIPTION
We want to be able to replicate the partial sync behavior when a file is created to support the following workflow: 
1. Create Java Class
2. Add the file to its folk targets by jump to build file from the folk and use auto-complete to include this new class
3. Then re-trigger add to module on the new Java class to resolve syntax for the class. 

This change expose the actions from create new file to a right click menu button to perform same activity on demand. 
