### PR TITLE
Apply ImportRunConfigurationsSyncHook.kt to ShConfigurationType

### DIFF
--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/run/import/ImportRunConfigurationsSyncHook.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/run/import/ImportRunConfigurationsSyncHook.kt
@@ -24,6 +24,7 @@ import org.jetbrains.bazel.sync.withSubtask
 import java.nio.file.Path
 
 private const val GOOGLE_BAZEL_RUN_CONFIG_TYPE = "BlazeCommandRunConfigurationType"
+private const val SHELL_SCRIPT_RUN_CONFIG_TYPE = "ShConfigurationType"
 
 internal class ImportRunConfigurationsSyncHook : ProjectSyncHook {
   private val log = logger<ImportRunConfigurationsSyncHook>()
@@ -61,12 +62,12 @@ internal class ImportRunConfigurationsSyncHook : ProjectSyncHook {
 
   private fun importRunConfiguration(project: Project, runConfigurationPath: Path): RunnerAndConfigurationSettings? {
     val runConfigurationXml = getConfigurationElement(JDOMUtil.load(runConfigurationPath)) ?: return null
-    val settings =
-      if (checkNotNull(runConfigurationXml.getAttributeValue("type")) == GOOGLE_BAZEL_RUN_CONFIG_TYPE) {
-        loadGoogleBazelRunConfiguration(project, runConfigurationXml)
-      } else {
-        loadRunConfigurationXmlNormally(project, runConfigurationXml)
-      }
+    val configurationType = checkNotNull(runConfigurationXml.getAttributeValue("type"))
+    val settings = when (configurationType) {
+      GOOGLE_BAZEL_RUN_CONFIG_TYPE -> loadGoogleBazelRunConfiguration(project, runConfigurationXml)
+      SHELL_SCRIPT_RUN_CONFIG_TYPE -> loadShellScriptRunConfiguration(project, runConfigurationXml)
+      else -> loadRunConfigurationXmlNormally(project, runConfigurationXml)
+    }
     return settings
   }
 
@@ -110,6 +111,41 @@ internal class ImportRunConfigurationsSyncHook : ProjectSyncHook {
 
     runManager.addConfiguration(settings)
     return settings
+  }
+
+  private fun loadShellScriptRunConfiguration(project: Project, runConfigurationXml: Element): RunnerAndConfigurationSettings {
+    // Create a copy of the XML element to modify it
+    val modifiedXml = runConfigurationXml.clone()
+    println(modifiedXml)
+    // Apply replaceProjectDir to the specified shell script configuration fields
+    modifiedXml.children.filter { it.name == "option" }.forEach { option ->
+      when (option.getAttributeValue("name")) {
+        "SCRIPT_TEXT" -> {
+          option.getAttributeValue("value")?.let { value ->
+            option.setAttribute("value", value.replaceProjectDir(project))
+          }
+        }
+        "SCRIPT_PATH" -> {
+          option.getAttributeValue("value")?.let { value ->
+            option.setAttribute("value", value.replaceProjectDir(project))
+          }
+        }
+        "SCRIPT_OPTIONS" -> {
+          option.getAttributeValue("value")?.let { value ->
+            option.setAttribute("value", value.replaceProjectDir(project))
+          }
+        }
+        "SCRIPT_WORKING_DIRECTORY" -> {
+          option.getAttributeValue("value")?.let { value ->
+            option.setAttribute("value", value.replaceProjectDir(project))
+          }
+        }
+      }
+    }
+
+    // Load the modified configuration normally
+    val runManager = RunManagerImpl.getInstanceImpl(project)
+    return runManager.loadConfiguration(modifiedXml, false)
   }
 
   /**


### PR DESCRIPTION
```
  /**
   * Google's plugin sets the $PROJECT_DIR$ to <workspace_root>/.ijwb, while we instead use plain <workspace_root>.
   * That means that even if we just copied Google's run configurations, loading them directly would still not be possible.
   * Example: Google's plugin serializes the path to MODULE.bazel as $PROJECT_DIR$/../MODULE.bazel instead of $PROJECT_DIR$/MODULE.bazel
   */
```
   
   This is basically applying whatever this comment says to ShConfigurationType so workspace opened in the new plugin can import correctly. 