### PR TITLE
Remove Project Level SDK Cleanup & Remove Startup Sync

### DIFF
--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/jvm/sync/SdkUtils.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/jvm/sync/SdkUtils.kt
@@ -46,9 +46,7 @@ object SdkUtils {
         }
       }
 
-    // We don't need the project SDK anyway. If the user sets it manually, it can cause red code, so remove it upon sync.
-    val rootManager = ProjectRootManager.getInstance(project)
-    writeAction { rootManager.projectSdk = null }
+    // Removed the project SDK cleanup logic, as we actually rely on it for SDK inheritance to avoid repetitive SDK import & indexing
   }
 
   private fun isValidJdk(sdk: Sdk): Boolean {

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/startup/BazelStartupActivity.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/startup/BazelStartupActivity.kt
@@ -29,7 +29,6 @@ import org.jetbrains.bazel.target.TargetUtils
 import org.jetbrains.bazel.ui.settings.BazelApplicationSettingsService
 import org.jetbrains.bazel.ui.widgets.fileTargets.updateBazelFileTargetsWidget
 import org.jetbrains.bazel.utils.configureRunConfigurationIgnoreProducers
-import org.jetbrains.bazel.sync.status.isSyncInProgress
 import java.nio.file.Path
 import kotlin.io.path.isDirectory
 
@@ -61,7 +60,7 @@ class BazelStartupActivity : BazelProjectActivity() {
 
       executeOnEveryProjectStartup(project)
 
-      runStartupSyncWithFeedback(project)
+      resyncProjectIfNeeded(project)
 
       executeOnSyncedProject(project)
 
@@ -80,21 +79,18 @@ private suspend fun executeOnEveryProjectStartup(project: Project) {
   disableUnableToFindJdkNotification(project)
 }
 
-private suspend fun runStartupSyncWithFeedback(project: Project) {
-  if (project.isSyncInProgress()) {
-    log.info("Skipping startup sync task because another sync is already running")
-    return
-  }
-
-  if (serviceAsync<BazelApplicationSettingsService>().settings.enablePhasedSync) {
-    log.info("Running Bazel phased sync task on startup")
-    PhasedSync(project).sync()
-  } else {
-    log.info("Running Bazel sync task on startup")
-    ProjectSyncTask(project).sync(
-      syncScope = SecondPhaseSync,
-      buildProject = BazelFeatureFlags.isBuildProjectOnSyncEnabled,
-    )
+private suspend fun resyncProjectIfNeeded(project: Project) {
+  if (isProjectInIncompleteState(project)) {
+    if (serviceAsync<BazelApplicationSettingsService>().settings.enablePhasedSync) {
+      log.info("Running Bazel phased sync task")
+      PhasedSync(project).sync()
+    } else {
+      log.info("Running Bazel sync task")
+      ProjectSyncTask(project).sync(
+        syncScope = SecondPhaseSync,
+        buildProject = BazelFeatureFlags.isBuildProjectOnSyncEnabled,
+      )
+    }
   }
 }
 

--- a/versions.bzl
+++ b/versions.bzl
@@ -1,6 +1,6 @@
 """Release versions of plugins. The file is swaped with versions.bzl on CI during release"""
 
-INTELLIJ_BAZEL_VERSION = "2025.1.14-sf11-built-to-2025.2"
+INTELLIJ_BAZEL_VERSION = "2025.2.7-sf0"
 
 PLATFORM_VERSION = "252"
 


### PR DESCRIPTION
Remove project level SDK cleanup, as our optimization leverages IntelliJ Project level SDK inheritance, to avoid repetitive SDK importing & Indexing per module. 

Validated:
1. Project Sync success with symbols properly resolved; 
2. Project remain resolved after restarting;
3. Jump to build file working properly; 
4. No freeze after git checkout recent branch, build and run test and auto suggestion remains agile
5. Not affected by irrelevant Bazel process generating files in same folder and auto suggestion remains agile
6. Proper Bazel Run Configuration Import
7. Proper Sh Run Configuration import
8. Debugger working