### PR TITLE
Fix JDK resolution when using Bazel JVM wrapper scripts

### DIFF
--- a/CONTEXT_DEVELOPMENT_261.md
+++ b/CONTEXT_DEVELOPMENT_261.md
@@ -3,6 +3,10 @@
 > **Maintenance tip**: Keep this file updated as you make progress — update the tip commit hash,
 > move completed work into the "Recently Completed" section, and revise the "Pending" section.
 > This file is the primary handoff document between sessions.
+>
+> **Next step guidance**: Only write a "Next step" when there is something actionable *after* a PR
+> merges. Don't write "get PR reviewed/merged" — this doc lives in the repo and is read post-merge,
+> so those entries are immediately stale. Use `—` or omit the field when nothing remains.
 
 ## Current State (as of 2026-08-10)
 

--- a/CONTEXT_DEVELOPMENT_261.md
+++ b/CONTEXT_DEVELOPMENT_261.md
@@ -63,7 +63,7 @@ Added `CONTEXT_DEVELOPMENT_261.md` as a persistent handoff document between sess
     2. Scan `execroot/_main/external/` for JDK directories, prefer those matching the version hint in the wrapper name
   - Helpers: `resolveRealJdkFromWrapper()`, `findJdkInExternalDir()`, `findExecRoot()`
 
-**Next step**: Get PR #31 reviewed and merged
+**Next step**: —
 
 ### Repo Context
 - This is a Snowflake fork of the JetBrains Bazel IntelliJ plugin (`hirschgarten`)

--- a/CONTEXT_DEVELOPMENT_261.md
+++ b/CONTEXT_DEVELOPMENT_261.md
@@ -1,9 +1,13 @@
 # Context for Next Task
 
+> **Maintenance tip**: Keep this file updated as you make progress — update the tip commit hash,
+> move completed work into the "Recently Completed" section, and revise the "Pending" section.
+> This file is the primary handoff document between sessions.
+
 ## Current State (as of 2026-08-10)
 
 ### Working Branch
-`development-261` — latest tip: `260af4c882 Merge pull request #29`
+`development-261` — latest tip: `98bc05a260 Merge pull request #30`
 
 ### Recently Completed Work (PR #29)
 
@@ -39,20 +43,27 @@ Two commits in this PR:
 - `plugin-bazel/src/main/kotlin/org/jetbrains/bazel/workspace/fileEvents/SimplifiedFileEvent.kt` — added `ExternalCreate` subclass
 - `plugin-bazel/src/main/kotlin/org/jetbrains/bazel/action/registered/AddFileToModuleAction.kt` — passes `packagePrefix` to `addToModule()`
 
+### Recently Completed Work (PR #30)
+
+**Branch**: `context/update-development-261-context` → merged into `development-261`
+
+Added `CONTEXT_DEVELOPMENT_261.md` as a persistent handoff document between sessions, then made the GitHub account note generic.
+
 ### Pending / In-Progress Work
 
-**JVM Wrapper JDK resolution** — separate branch `fix/resolve-jvm-wrapper-jdk-home`, NOT yet merged, NO PR yet.
+**JVM Wrapper JDK resolution** — branch `fix/resolve-jvm-wrapper-jdk-home`, PR #31 open (→ `development-261`).
 
 **Problem**: When a project uses `jvm_wrapper_runtime`, the `java_home` from the Bazel aspect points to the wrapper directory (contains only `bin/java` as a shell script), not the actual JDK. IntelliJ's `JavaSdk.isValidSdkHome()` fails for this path → "JDK not found on disk or corrupted" warning after sync.
 
-**Fix implemented** (on `fix/resolve-jvm-wrapper-jdk-home`):
+**Fix implemented** (on `fix/resolve-jvm-wrapper-jdk-home`, rebased onto `development-261`):
 - `plugin-bazel/src/main/kotlin/org/jetbrains/bazel/jvm/sync/SdkUtils.kt`
-  - Added `resolveJavaHome(javaHome: Path, project: Project): Path`
-  - If `javaHome` is not a valid JDK: reads `bin/java` as text, parses `exec` lines to find real java binary relative to Bazel exec root, derives actual JDK home
+  - `addJdkIfNeeded()` now calls `resolveJavaHome()` before creating the SDK
+  - `resolveJavaHome()`: fast-path returns early if already a valid JDK; otherwise tries:
+    1. Parse `{javaHome}/bin/java` wrapper script for `exec .../bin/java` lines, resolve against Bazel exec root
+    2. Scan `execroot/_main/external/` for JDK directories, prefer those matching the version hint in the wrapper name
   - Helpers: `resolveRealJdkFromWrapper()`, `findJdkInExternalDir()`, `findExecRoot()`
-- Note: this fix is on a REMOTE machine; `jvm_wrapper_runtime` creates a `java_runtime` with `java_home` pointing to wrapper dir (`jdk21_jvm_wrapper_wrapper_script`)
 
-**Next step**: Create a PR from `fix/resolve-jvm-wrapper-jdk-home` → `development-261`
+**Next step**: Get PR #31 reviewed and merged
 
 ### Repo Context
 - This is a Snowflake fork of the JetBrains Bazel IntelliJ plugin (`hirschgarten`)

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/jvm/sync/SdkUtils.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/jvm/sync/SdkUtils.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.bazel.jvm.sync
 
 import com.intellij.openapi.application.writeAction
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.externalSystem.service.execution.ExternalSystemJdkProvider
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.JavaSdk
@@ -13,15 +14,128 @@ import org.jetbrains.bazel.config.bazelProjectName
 import org.jetbrains.bazel.magicmetamodel.impl.workspacemodel.impl.updaters.transformers.projectNameToBaseJdkName
 import org.jetbrains.bazel.magicmetamodel.impl.workspacemodel.impl.updaters.transformers.projectNameToJdkName
 import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.readText
+
+private val logger = Logger.getInstance(SdkUtils::class.java)
 
 internal object SdkUtils {
   suspend fun addJdkIfNeeded(projectName: String, javaHome: Path) {
-    val jdkName = projectName.projectNameToJdkName(javaHome)
+    // Resolve through JVM wrapper scripts if javaHome is not a valid JDK directory.
+    // Bazel JVM wrappers (e.g., jvm_wrapper_runtime) create a java_runtime whose java_home
+    // points to a directory containing only bin/java (a shell script), not a full JDK.
+    // In that case, parse the wrapper to find the real JDK path.
+    val resolvedHome = resolveJavaHome(javaHome)
+    val jdkName = projectName.projectNameToJdkName(resolvedHome)
     // Normalize the JDK path, because some code in the platform compares paths using `startsWith`, e.g.
     // https://github.com/JetBrains/intellij-community/blob/b41a4084da5521effedd334e28896fd9d07410da/java/codeserver/core/src/com/intellij/java/codeserver/core/JpmsModuleAccessInfo.kt#L216
-    val path = javaHome.normalize().toString()
+    val path = resolvedHome.normalize().toString()
     val jdk = ExternalSystemJdkProvider.getInstance().createJdk(jdkName, path)
     addSdkIfNeeded(jdk)
+  }
+
+  /**
+   * If [javaHome] is a valid JDK home, returns it as-is.
+   * Otherwise, attempts to resolve the real JDK through multiple strategies:
+   * 1. Parse the wrapper script at `{javaHome}/bin/java` for exec paths
+   * 2. Scan `external/` under the Bazel exec root for a matching JDK
+   */
+  private fun resolveJavaHome(javaHome: Path): Path {
+    if (javaSdkInstance.isValidSdkHome(javaHome.normalize().toString())) {
+      return javaHome
+    }
+    logger.info("javaHome is not a valid JDK, attempting to resolve: $javaHome")
+    val execRoot = findExecRoot(javaHome)
+
+    // Strategy 1: Read the wrapper script if it exists
+    val javaBin = javaHome.resolve("bin/java")
+    if (javaBin.isRegularFile()) {
+      try {
+        val resolved = resolveRealJdkFromWrapper(javaBin.readText(), execRoot)
+        if (resolved != null) return resolved
+      } catch (e: Exception) {
+        logger.debug("Failed to parse wrapper script: $javaBin", e)
+      }
+    }
+
+    // Strategy 2: Scan external/ for a JDK matching the version hint in the path name
+    if (execRoot != null) {
+      val resolved = findJdkInExternalDir(execRoot, javaHome)
+      if (resolved != null) return resolved
+    }
+
+    return javaHome
+  }
+
+  /**
+   * Parses a JVM wrapper shell script to extract the real JDK home path.
+   */
+  private fun resolveRealJdkFromWrapper(scriptContent: String, execRoot: Path?): Path? {
+    if (execRoot == null) return null
+    // Match exec lines like: exec "path/to/bin/java" or exec path/to/bin/java
+    val execPattern = Regex("""exec\s+["']?([^"'\s]+/bin/java)["']?""")
+    for (match in execPattern.findAll(scriptContent)) {
+      val javaPath = match.groupValues[1]
+      // Skip lines with variable substitutions (e.g., $JAVA_RUNFILES)
+      if ('$' in javaPath || '{' in javaPath) continue
+      val resolvedJava = execRoot.resolve(javaPath)
+      val resolvedHome = resolvedJava.parent?.parent // bin/java -> jdk_home
+      if (resolvedHome != null && resolvedHome.exists() &&
+        javaSdkInstance.isValidSdkHome(resolvedHome.normalize().toString())
+      ) {
+        logger.info("Resolved JVM wrapper to real JDK via script: $resolvedHome")
+        return resolvedHome
+      }
+    }
+    return null
+  }
+
+  /**
+   * Scans the `external/` directory under the Bazel exec root for a valid JDK.
+   * Uses the wrapper path name to infer the JDK version (e.g., "jdk21" from
+   * "jdk21_jvm_wrapper_wrapper_script") and looks for matching directories.
+   */
+  private fun findJdkInExternalDir(execRoot: Path, wrapperHome: Path): Path? {
+    val externalDir = execRoot.resolve("external")
+    if (!externalDir.exists()) return null
+
+    // Extract version hint from the wrapper path (e.g., "jdk21" from "jdk21_jvm_wrapper_wrapper_script")
+    val wrapperName = wrapperHome.fileName?.toString() ?: ""
+    val versionHint = Regex("""jdk(\d+)""").find(wrapperName)?.groupValues?.get(1)
+
+    val candidates = externalDir.toFile().listFiles { file ->
+      file.isDirectory && file.name.contains("jdk", ignoreCase = true)
+    } ?: return null
+
+    // Prefer candidates matching the version hint
+    val sorted = if (versionHint != null) {
+      candidates.sortedByDescending { it.name.contains(versionHint) }
+    } else {
+      candidates.toList()
+    }
+
+    for (candidate in sorted) {
+      val candidatePath = candidate.toPath()
+      if (javaSdkInstance.isValidSdkHome(candidatePath.normalize().toString())) {
+        logger.info("Resolved JVM wrapper to real JDK via external/ scan: $candidatePath")
+        return candidatePath
+      }
+    }
+    return null
+  }
+
+  private fun findExecRoot(path: Path): Path? {
+    var current = path
+    while (current.parent != null) {
+      if (current.fileName?.toString() == "_main" &&
+        current.parent?.fileName?.toString() == "execroot"
+      ) {
+        return current
+      }
+      current = current.parent
+    }
+    return null
   }
 
   suspend fun addSdkIfNeeded(sdk: Sdk) {


### PR DESCRIPTION
## Summary

- When a project uses `jvm_wrapper_runtime`, the `java_runtime`'s `java_home` points to the wrapper directory (contains only `bin/java` as a shell script), not the actual JDK
- `JavaSdk.isValidSdkHome()` fails for this path → "JDK not found on disk or corrupted" warning after every sync
- Fixed in `SdkUtils.addJdkIfNeeded()` by calling `resolveJavaHome()` before creating the SDK

## How it works

`resolveJavaHome()` first checks if the path is already a valid JDK (fast path, no change for normal projects). If not, it tries two resolution strategies:

1. **Parse wrapper script** — reads `{javaHome}/bin/java`, finds `exec .../bin/java` lines, resolves against Bazel exec root, validates with `isValidSdkHome()`
2. **Scan `external/`** — walks `execroot/_main/external/` looking for JDK directories, preferring ones matching the version hint in the wrapper name (e.g., `jdk21` from `jdk21_jvm_wrapper_wrapper_script`)

Falls back to the original `javaHome` if neither strategy succeeds (preserves existing behavior for unknown layouts).

## Test plan

- [x] Open a project that uses `jvm_wrapper_runtime` and verify no "JDK not found" warning after sync
- [x] Open a project with a normal JDK (non-wrapper) and verify behavior is unchanged
- [x] Verify the resolved SDK path points to a full JDK with `release` file and `lib/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)