### PR TITLE
Add non_bazel_python_directories section to .bazelproject

### DIFF
--- a/CONTEXT_DEVELOPMENT_261.md
+++ b/CONTEXT_DEVELOPMENT_261.md
@@ -1,9 +1,17 @@
 # Context for Next Task
 
-## Current State (as of 2026-08-10)
+> **Maintenance tip**: Keep this file updated as you make progress — update the tip commit hash,
+> move completed work into the "Recently Completed" section, and revise the "Pending" section.
+> This file is the primary handoff document between sessions.
+>
+> **Next step guidance**: Only write a "Next step" when there is something actionable *after* a PR
+> merges. Don't write "get PR reviewed/merged" — this doc lives in the repo and is read post-merge,
+> so those entries are immediately stale. Use `—` or omit the field when nothing remains.
+
+## Current State (as of 2026-08-11)
 
 ### Working Branch
-`development-261` — latest tip: `260af4c882 Merge pull request #29`
+`development-261` — latest tip: `98bc05a260 Merge pull request #30`
 
 ### Recently Completed Work (PR #29)
 
@@ -24,35 +32,48 @@ Two commits in this PR:
 
 **Optimization**: `addFileToTargets()` in `BazelFileEventListener` was calling `fetchAndCacheUnsyncedTarget()` once per unsynced target (N individual BSP RPCs). Refactored into a 3-phase approach: collect all unsynced labels → single batch RPC via `fetchAndCacheUnsyncedTargets()` → add files to modules.
 
-#### Key files changed
-- `plugin-bazel/src/main/kotlin/org/jetbrains/bazel/workspace/ModuleAssignmentUtils.kt` (new, replaces `AssignFileToModuleListener.kt`)
-  - `addToModule()` — now creates `JavaSourceRootPropertiesEntity` with `packagePrefix`
-  - `resolvePackagePrefix()` — looks up `PackageMarkerEntity` for the parent directory
-  - `getModulesForFile()`, `askForInverseSources()`, `processTargetsForTestlibStripping()`
-- `plugin-bazel/src/main/kotlin/org/jetbrains/bazel/workspace/AssignFileToModuleListener.kt` (deleted)
-- `plugin-bazel/src/main/kotlin/org/jetbrains/bazel/workspace/UnsyncedTargetUpdater.kt`
-  - Added `fetchAndCacheUnsyncedTargets(labels: List<Label>, ...)` — batch BSP call via `WorkspaceBuildTargetSelector.SpecificTargets(labels)`
-- `plugin-bazel/src/main/kotlin/org/jetbrains/bazel/workspace/fileEvents/BazelFileEventListener.kt`
-  - `addFileToTargets()` refactored: 3-phase batch approach
-  - Added `enqueueExternalEvents()` companion method (internal) for `BazelFileEventSubmitter`
-- `plugin-bazel/src/main/kotlin/org/jetbrains/bazel/workspace/BazelFileEventSubmitter.kt` — routes to `BazelFileEventListener.enqueueExternalEvents()`
-- `plugin-bazel/src/main/kotlin/org/jetbrains/bazel/workspace/fileEvents/SimplifiedFileEvent.kt` — added `ExternalCreate` subclass
-- `plugin-bazel/src/main/kotlin/org/jetbrains/bazel/action/registered/AddFileToModuleAction.kt` — passes `packagePrefix` to `addToModule()`
+### Recently Completed Work (PR #30)
+
+**Branch**: `context/update-development-261-context` → merged into `development-261`
+
+Added `CONTEXT_DEVELOPMENT_261.md` as a persistent handoff document.
 
 ### Pending / In-Progress Work
 
-**JVM Wrapper JDK resolution** — separate branch `fix/resolve-jvm-wrapper-jdk-home`, NOT yet merged, NO PR yet.
+**JVM Wrapper JDK resolution** — branch `fix/resolve-jvm-wrapper-jdk-home`, PR #31 open (→ `development-261`).
 
 **Problem**: When a project uses `jvm_wrapper_runtime`, the `java_home` from the Bazel aspect points to the wrapper directory (contains only `bin/java` as a shell script), not the actual JDK. IntelliJ's `JavaSdk.isValidSdkHome()` fails for this path → "JDK not found on disk or corrupted" warning after sync.
 
-**Fix implemented** (on `fix/resolve-jvm-wrapper-jdk-home`):
+**Fix implemented** (on `fix/resolve-jvm-wrapper-jdk-home`, rebased onto `development-261`):
 - `plugin-bazel/src/main/kotlin/org/jetbrains/bazel/jvm/sync/SdkUtils.kt`
-  - Added `resolveJavaHome(javaHome: Path, project: Project): Path`
-  - If `javaHome` is not a valid JDK: reads `bin/java` as text, parses `exec` lines to find real java binary relative to Bazel exec root, derives actual JDK home
+  - `addJdkIfNeeded()` now calls `resolveJavaHome()` before creating the SDK
+  - `resolveJavaHome()`: fast-path returns early if already a valid JDK; otherwise tries:
+    1. Parse `{javaHome}/bin/java` wrapper script for `exec .../bin/java` lines, resolve against Bazel exec root
+    2. Scan `execroot/_main/external/` for JDK directories, prefer those matching the version hint in the wrapper name
   - Helpers: `resolveRealJdkFromWrapper()`, `findJdkInExternalDir()`, `findExecRoot()`
-- Note: this fix is on a REMOTE machine; `jvm_wrapper_runtime` creates a `java_runtime` with `java_home` pointing to wrapper dir (`jdk21_jvm_wrapper_wrapper_script`)
 
-**Next step**: Create a PR from `fix/resolve-jvm-wrapper-jdk-home` → `development-261`
+**Next step**: —
+
+---
+
+**Non-Bazel Python directories** — branch `feat/non-bazel-python-directories`, PR #32 open (→ `development-261`).
+
+**Problem**: Python files not covered by any Bazel target inherit the Java SDK → no Python code intelligence, IDE freezes.
+
+**Fix implemented** (on `feat/non-bazel-python-directories`):
+- New `.bazelproject` section `non_bazel_python_directories:` — lists directories explicitly
+- `NonBazelPythonDirectoriesSection.kt` (new) — parses the section as `List<Path>`
+- `ProjectViewExtensions.kt` — adds `ProjectView.nonBazelPythonDirectories` extension property
+- `PythonProjectSync.kt` — `createFallbackPythonModuleIfNeeded()` replaced: reads the explicit list, resolves relative paths against workspace root, creates one module per listed directory with a Python SDK; falls back to `findPythonSdk()` when no Python Bazel targets exist
+
+Example `.bazelproject` usage:
+```
+non_bazel_python_directories:
+  Snowfort
+  tools/scripts
+```
+
+**Next step**: —
 
 ### Repo Context
 - This is a Snowflake fork of the JetBrains Bazel IntelliJ plugin (`hirschgarten`)

--- a/intellij.bazel.projectview/src/org/jetbrains/bazel/languages/projectview/ProjectViewExtensions.kt
+++ b/intellij.bazel.projectview/src/org/jetbrains/bazel/languages/projectview/ProjectViewExtensions.kt
@@ -22,6 +22,7 @@ import org.jetbrains.bazel.languages.projectview.sections.ImportIjarsSection
 import org.jetbrains.bazel.languages.projectview.sections.ImportRunConfigurationsSection
 import org.jetbrains.bazel.languages.projectview.sections.IndexAllFilesInDirectoriesSection
 import org.jetbrains.bazel.languages.projectview.sections.PreferClassJarsOverSourcelessJarsSection
+import org.jetbrains.bazel.languages.projectview.sections.NonBazelPythonDirectoriesSection
 import org.jetbrains.bazel.languages.projectview.sections.PythonCodeGeneratorRuleNamesSection
 import org.jetbrains.bazel.languages.projectview.sections.PythonDebugFlagsSection
 import org.jetbrains.bazel.languages.projectview.sections.RunConfigRunWithBazelSection
@@ -116,6 +117,10 @@ val ProjectView.gazelleTarget: Label?
 val ProjectView.indexAllFilesInDirectories: Boolean
   @ApiStatus.Internal
   get() = getSection(IndexAllFilesInDirectoriesSection.KEY) ?: false
+
+val ProjectView.nonBazelPythonDirectories: List<Path>
+  @ApiStatus.Internal
+  get() = getSection(NonBazelPythonDirectoriesSection.KEY) ?: emptyList()
 
 val ProjectView.pythonCodeGeneratorRuleNames: List<String>
   @ApiStatus.Internal

--- a/intellij.bazel.projectview/src/org/jetbrains/bazel/languages/projectview/ProjectViewSectionProvider.kt
+++ b/intellij.bazel.projectview/src/org/jetbrains/bazel/languages/projectview/ProjectViewSectionProvider.kt
@@ -20,6 +20,7 @@ import org.jetbrains.bazel.languages.projectview.sections.ImportIjarsSection
 import org.jetbrains.bazel.languages.projectview.sections.ImportRunConfigurationsSection
 import org.jetbrains.bazel.languages.projectview.sections.IndexAllFilesInDirectoriesSection
 import org.jetbrains.bazel.languages.projectview.sections.PreferClassJarsOverSourcelessJarsSection
+import org.jetbrains.bazel.languages.projectview.sections.NonBazelPythonDirectoriesSection
 import org.jetbrains.bazel.languages.projectview.sections.PythonCodeGeneratorRuleNamesSection
 import org.jetbrains.bazel.languages.projectview.sections.PythonDebugFlagsSection
 import org.jetbrains.bazel.languages.projectview.sections.RunConfigRunWithBazelSection
@@ -59,6 +60,7 @@ internal class DefaultProjectViewSectionProvider : ProjectViewSectionProvider {
       ImportIjarsSection(),
       ImportRunConfigurationsSection(),
       IndexAllFilesInDirectoriesSection(),
+      NonBazelPythonDirectoriesSection(),
       PythonCodeGeneratorRuleNamesSection(),
       PythonDebugFlagsSection(),
       ShardingApproachSection(),

--- a/intellij.bazel.projectview/src/org/jetbrains/bazel/languages/projectview/sections/NonBazelPythonDirectoriesSection.kt
+++ b/intellij.bazel.projectview/src/org/jetbrains/bazel/languages/projectview/sections/NonBazelPythonDirectoriesSection.kt
@@ -1,0 +1,32 @@
+package org.jetbrains.bazel.languages.projectview.sections
+
+import org.jetbrains.annotations.ApiStatus
+import org.jetbrains.bazel.languages.projectview.ListSection
+import org.jetbrains.bazel.languages.projectview.SectionKey
+import java.nio.file.Path
+
+@ApiStatus.Internal
+class NonBazelPythonDirectoriesSection : ListSection<List<Path>>() {
+  override val name = NAME
+  override val default = emptyList<Path>()
+  override val sectionKey = KEY
+  override val doc =
+    "A list of directories containing Python files that are not part of any Bazel target. " +
+      "The plugin will create one IntelliJ module per listed directory and assign a Python SDK to it, " +
+      "ensuring those files have code intelligence without being part of a Bazel python_library or py_binary target. " +
+      "Paths are relative to the workspace root."
+
+  override fun fromRawValues(rawValues: List<String>): List<Path> =
+    rawValues.mapNotNull { value ->
+      try {
+        Path.of(value)
+      } catch (_: Exception) {
+        null
+      }
+    }
+
+  companion object {
+    const val NAME = "non_bazel_python_directories"
+    val KEY = SectionKey<List<Path>>(NAME)
+  }
+}

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/python/sync/PythonProjectSync.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/python/sync/PythonProjectSync.kt
@@ -56,6 +56,8 @@ import org.jetbrains.bsp.protocol.BuildTarget
 import org.jetbrains.bsp.protocol.PythonBuildTarget
 import org.jetbrains.bsp.protocol.RawBuildTarget
 import org.jetbrains.bsp.protocol.utils.extractPythonBuildTarget
+import org.jetbrains.bazel.languages.projectview.ProjectViewService
+import org.jetbrains.bazel.languages.projectview.nonBazelPythonDirectories
 import java.nio.file.Path
 
 private const val PYTHON_SDK_ID = "PythonSDK"
@@ -98,7 +100,8 @@ class PythonProjectSync : ProjectSyncHook {
         )
       }
 
-      // Create a fallback module for non-target Python files in included directories
+      // Create modules for directories listed under non_bazel_python_directories: in .bazelproject.
+      // pythonTargets is passed so we can skip any directory already covered by a Bazel Python target.
       createFallbackPythonModuleIfNeeded(
         environment = environment,
         pythonTargets = pythonTargets,
@@ -300,10 +303,13 @@ class PythonProjectSync : ProjectSyncHook {
     }
 
   /**
-   * Creates fallback Python modules for files in included directories that are not part of any Python target.
-   * This ensures that Python files outside of targets still get a Python SDK instead of falling back to the
-   * project-level Java SDK.
-   * Creates one module per root-level folder to allow different folder-level settings.
+   * Creates Python modules for directories listed under `non_bazel_python_directories:` in the .bazelproject file.
+   * Each listed directory gets its own module with a Python SDK, giving code intelligence to Python files
+   * that are not part of any Bazel target.
+   *
+   * [pythonTargets] are the Bazel-managed Python targets (handled elsewhere in [onSync]). They are used here
+   * only to skip any explicitly listed directory that is already covered by a Bazel target, preventing
+   * duplicate modules.
    */
   private suspend fun createFallbackPythonModuleIfNeeded(
     environment: ProjectSyncHookEnvironment,
@@ -312,86 +318,72 @@ class PythonProjectSync : ProjectSyncHook {
     defaultSdk: Sdk?,
     virtualFileUrlManager: VirtualFileUrlManager,
   ) {
-    // Prefer any Python SDK from Bazel sync, fall back to system SDK
-    // Validate that we only use actual Python SDKs, not JDK or other SDK types
     val pythonSdkType = PythonSdkType.getInstance()
     val pythonSdk = sdks.values.firstOrNull { sdk ->
       sdk != null && sdk.sdkType == pythonSdkType
     } ?: defaultSdk?.takeIf { it.sdkType == pythonSdkType }
+    ?: findPythonSdk(environment.project)
     if (pythonSdk == null) {
       return
     }
-    val builder = environment.diff
 
-    // Get the BazelProjectDirectoriesEntity to know which directories are included
-    // Query from the mutableEntityStorage being built, not the current snapshot
-    val directoriesEntity = builder.entities(BazelProjectDirectoriesEntity::class.java).firstOrNull()
-    if (directoriesEntity == null || directoriesEntity.includedRoots.isEmpty()) {
-      // No included directories, nothing to do
-      return
-    }
+    val projectView = ProjectViewService.getInstance(environment.project).getProjectView()
+    val nonBazelDirs = projectView.nonBazelPythonDirectories
+    if (nonBazelDirs.isEmpty()) return
 
-    // Collect all directories that are already covered by Python targets
+    // Collect source URLs already covered by Bazel Python targets so we can skip duplicates
     val targetCoveredUrls = pythonTargets.flatMap { target ->
       (target as RawBuildTarget).sources.map { it.path.toVirtualFileUrl(virtualFileUrlManager) }
     }.toSet()
 
-    // Find included roots that are not covered by any Python target
-    val uncoveredRoots = directoriesEntity.includedRoots.filterNot { includedRoot ->
-      // Check if this included root is already covered by a target
-      targetCoveredUrls.any { targetUrl ->
-        targetUrl.url.startsWith(includedRoot.url) || includedRoot.url.startsWith(targetUrl.url)
+    // Resolve relative paths against the workspace root
+    val builder = environment.diff
+    val projectRootPath = builder.entities(BazelProjectDirectoriesEntity::class.java)
+      .firstOrNull()
+      ?.projectRoot
+      ?.url
+      ?.let { runCatching { Path.of(java.net.URI(it)) }.getOrNull() }
+
+    nonBazelDirs.forEach { dirPath ->
+      val absolutePath = if (dirPath.isAbsolute) dirPath else projectRootPath?.resolve(dirPath) ?: dirPath
+      val dirUrl = absolutePath.toVirtualFileUrl(virtualFileUrlManager)
+
+      // Skip directories already covered by a Bazel Python target
+      if (targetCoveredUrls.any { it.url.startsWith(dirUrl.url) || dirUrl.url.startsWith(it.url) }) {
+        LOG.info("Skipping non-Bazel Python directory '$absolutePath': already covered by a Bazel target")
+        return@forEach
       }
-    }
+      val folderName = absolutePath.fileName?.toString() ?: absolutePath.toString()
+      val moduleName = "${environment.project.name}.python.$folderName"
+      val entitySource = BazelModuleEntitySource(moduleName)
 
-    if (uncoveredRoots.isEmpty()) {
-      // All included directories are covered by targets
-      return
-    }
-
-    // Create one module per root-level folder to allow different folder-level settings
-    uncoveredRoots.forEach { rootUrl ->
-      // Extract folder name from URL (e.g., "file:///path/to/root/folder1" -> "folder1")
-      val folderName = rootUrl.url.trimEnd('/').substringAfterLast('/')
-      val fallbackModuleName = "${environment.project.name}.python.$folderName"
-      val fallbackEntitySource = BazelModuleEntitySource(fallbackModuleName)
-
-      // Create content root for this directory
       val sourceRootEntity = SourceRootEntity(
-        url = rootUrl,
+        url = dirUrl,
         rootTypeId = SourceRootTypeId(PYTHON_SOURCE_ROOT_TYPE),
-        entitySource = fallbackEntitySource,
+        entitySource = entitySource,
       )
       val contentRoot = ContentRootEntity(
-        url = rootUrl,
+        url = dirUrl,
         excludedPatterns = emptyList(),
-        entitySource = fallbackEntitySource,
+        entitySource = entitySource,
       ) {
         this.excludedUrls = emptyList()
         this.sourceRoots = listOf(sourceRootEntity)
       }
 
-      // Create the fallback module with Python SDK from Bazel sync
-      // Use JAVA module type (default) with Python SDK - IntelliJ respects Python folders this way
-      // ModuleSourceDependency is crucial - it's the "<module source>" entry that tells IntelliJ
-      // to recognize the module's own content roots as source folders
-      val dependencies = listOf(
-        ModuleSourceDependency,
-        pythonSdk.toModuleDependencyItem(),
-      )
-
+      // ModuleSourceDependency is the "<module source>" entry that tells IntelliJ to recognise
+      // the module's own content roots as source folders.
       builder.addEntity(
         ModuleEntity(
-          name = fallbackModuleName,
-          dependencies = dependencies,
-          entitySource = fallbackEntitySource,
+          name = moduleName,
+          dependencies = listOf(ModuleSourceDependency, pythonSdk.toModuleDependencyItem()),
+          entitySource = entitySource,
         ) {
-          // Use default JAVA module type - IntelliJ will respect Python folders with Python SDK
           this.contentRoots = listOf(contentRoot)
         },
       )
 
-      LOG.info("Created fallback Python module: $fallbackModuleName for folder: $folderName with Python SDK: ${pythonSdk.name}")
+      LOG.info("Created non-Bazel Python module '$moduleName' for '$absolutePath' with SDK '${pythonSdk.name}'")
     }
   }
 }


### PR DESCRIPTION
## Summary

- Replaces the auto-detection fallback with an explicit opt-in: list directories containing Python files not covered by any Bazel target under `non_bazel_python_directories:` in `.bazelproject`
- The plugin creates one IntelliJ module per listed directory and assigns a Python SDK, preventing those files from inheriting the Java SDK and losing code intelligence
- Paths are relative to the workspace root (absolute paths also accepted)

## New .bazelproject section

```
non_bazel_python_directories:
  scripts
  tools/python_utils
```

## What changed

- **`NonBazelPythonDirectoriesSection.kt`** (new) — parses the new section as `List<Path>`
- **`ProjectViewSectionProvider.kt`** — registers the new section
- **`ProjectViewExtensions.kt`** — adds `ProjectView.nonBazelPythonDirectories` extension property
- **`PythonProjectSync.kt`** — replaces `createFallbackPythonModuleIfNeeded`'s auto-detection with explicit directory list; falls back to `findPythonSdk()` when no Python Bazel targets exist

## Why explicit vs auto-detect

The previous approach subtracted Python target source roots from `BazelProjectDirectoriesEntity.includedRoots` and created modules for the remainder. This created modules for *any* uncovered directory and made the indexing much slower, which could be unexpected. Explicit opt-in is safer and way faster.

## Test plan

- [ ] Add `non_bazel_python_directories: Snowfort` to `.bazelproject`, sync, verify a `{project}.python.Snowfort` module appears with a Python SDK
- [ ] Verify files in that directory have Python code intelligence (no yellow SDK warning)
- [ ] Verify projects with no `non_bazel_python_directories:` section create no extra modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)