### PR TITLE
Fix project SDK and module SDKs after JVM wrapper JDK resolution

### DIFF
--- a/CONTEXT_DEVELOPMENT_261.md
+++ b/CONTEXT_DEVELOPMENT_261.md
@@ -8,56 +8,39 @@
 > merges. Don't write "get PR reviewed/merged" — this doc lives in the repo and is read post-merge,
 > so those entries are immediately stale. Use `—` or omit the field when nothing remains.
 
-## Current State (as of 2026-08-11)
-
+## Current State (as of 2026-08-12)
 
 ### Working Branch
-`development-261` — latest tip: `98bc05a260 Merge pull request #30`
+`development-261` — latest tip: `669b674a0b Merge pull request #32`
 
-### Recently Completed Work (PR #29)
+### Recently Completed Work (PR #31)
 
-**Branch**: `fix/add-java-source-root-properties-on-file-add` → merged into `development-261`
+**Branch**: `fix/resolve-jvm-wrapper-jdk-home` → merged into `development-261`
 
-Two commits in this PR:
-1. `18baa6588b` — Fix missing `JavaSourceRootPropertiesEntity` when adding new files to modules
-2. `20e33fe445` — Batch unsynced target RPCs: N calls → 1 for new file sync
+**Problem**: When a project uses `jvm_wrapper_runtime`, the `java_home` from the Bazel aspect points to the wrapper directory (contains only `bin/java` as a shell script), not the actual JDK. IntelliJ's `JavaSdk.isValidSdkHome()` fails → "JDK not found on disk or corrupted" warning after sync.
 
-#### What was fixed
+**Fix** (`SdkUtils.kt`): `addJdkIfNeeded()` now calls `resolveJavaHome()` before creating the SDK. `resolveJavaHome()` tries two strategies: (1) parse `bin/java` wrapper script for `exec .../bin/java` lines and resolve against Bazel exec root; (2) scan `execroot/_main/external/` for JDK directories.
 
-**Bug**: When a new `.java`/`.kt` file was added to a Bazel target:
-- No code intelligence until file was closed and reopened
-- Alt+Enter import resolution failed for other files importing from the new class
-- Root cause: `addToModule()` created a `SourceRootEntity` but never attached a `JavaSourceRootPropertiesEntity` with `packagePrefix` — IntelliJ's `SingleFileSourcesTrackerImpl.getPackageNameForSingleFileSource()` returned null without it
+### Recently Completed Work (PR #32)
 
-**Deduplication**: Removed the dead `AssignFileToModuleListener` class (it was not registered in `plugin.xml` — upstream had already moved functionality to `BazelFileEventListener`). Kept utility functions in a new `ModuleAssignmentUtils.kt`.
+**Branch**: `feat/non-bazel-python-directories` → merged into `development-261`
 
-**Optimization**: `addFileToTargets()` in `BazelFileEventListener` was calling `fetchAndCacheUnsyncedTarget()` once per unsynced target (N individual BSP RPCs). Refactored into a 3-phase approach: collect all unsynced labels → single batch RPC via `fetchAndCacheUnsyncedTargets()` → add files to modules.
+**Problem**: Python files not covered by any Bazel target inherit the Java SDK → no Python code intelligence.
 
-### Recently Completed Work (PR #30)
-
-**Branch**: `context/update-development-261-context` → merged into `development-261`
-
-Added `CONTEXT_DEVELOPMENT_261.md` as a persistent handoff document.
-
-### Recently Completed Work (PR #30)
-
-**Branch**: `context/update-development-261-context` → merged into `development-261`
-
-Added `CONTEXT_DEVELOPMENT_261.md` as a persistent handoff document between sessions, then made the GitHub account note generic.
+**Fix**: New `.bazelproject` section `non_bazel_python_directories:` — explicitly list directories. The plugin creates one IntelliJ module per listed directory with a Python SDK. Bazel-covered directories are skipped to avoid duplicate modules.
 
 ### Pending / In-Progress Work
 
-**JVM Wrapper JDK resolution** — branch `fix/resolve-jvm-wrapper-jdk-home`, PR #31 open (→ `development-261`).
+**JVM wrapper project SDK regression** — branch `fix/jvm-wrapper-project-sdk`, PR #33 open (→ `development-261`).
 
-**Problem**: When a project uses `jvm_wrapper_runtime`, the `java_home` from the Bazel aspect points to the wrapper directory (contains only `bin/java` as a shell script), not the actual JDK. IntelliJ's `JavaSdk.isValidSdkHome()` fails for this path → "JDK not found on disk or corrupted" warning after sync.
+**Problem**: PR #31 introduced two regressions:
+1. The project SDK is reported as "not configured" — `defaultJdkName` hashed the raw wrapper path but the SDK was registered under the resolved path; the names diverged so `setProjectSdk` couldn't find it.
+2. Target modules showed red code — `ModuleDetailsToJavaModuleTransformer` computes `jvmJdkName` from the raw wrapper path, but after PR #31 only the resolved-path SDK was registered, so the module SDK dependency resolved to a non-existent SDK.
 
-**Fix implemented** (on `fix/resolve-jvm-wrapper-jdk-home`, rebased onto `development-261`):
-- `plugin-bazel/src/main/kotlin/org/jetbrains/bazel/jvm/sync/SdkUtils.kt`
-  - `addJdkIfNeeded()` now calls `resolveJavaHome()` before creating the SDK
-  - `resolveJavaHome()`: fast-path returns early if already a valid JDK; otherwise tries:
-    1. Parse `{javaHome}/bin/java` wrapper script for `exec .../bin/java` lines, resolve against Bazel exec root
-    2. Scan `execroot/_main/external/` for JDK directories, prefer those matching the version hint in the wrapper name
-  - Helpers: `resolveRealJdkFromWrapper()`, `findJdkInExternalDir()`, `findExecRoot()`
+**Fix** (on `fix/jvm-wrapper-project-sdk`):
+- `SdkUtils.resolveJavaHome()` widened from `private` to `internal`
+- `CollectProjectDetailsTask.kt`: `defaultJdkName` now derived from `SdkUtils.resolveJavaHome(it.first())` (resolved path) — fixes regression #1
+- `SdkUtils.addJdkIfNeeded()`: when `resolvedHome != javaHome`, also registers an alias SDK under the original wrapper-path name pointing to the same real JDK — fixes regression #2
 
 **Next step**: —
 

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/jvm/sync/CollectProjectDetailsTask.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/jvm/sync/CollectProjectDetailsTask.kt
@@ -78,7 +78,9 @@ internal class CollectProjectDetailsTask(
       calculateAllUniqueJdkInfosSubtask(projectDetails)
       uniqueJavaHomes.orEmpty().also {
         if (it.isNotEmpty()) {
-          projectDetails.defaultJdkName = project.bazelProjectName.projectNameToJdkName(it.first())
+          // Resolve through JVM wrapper scripts before computing the name so it matches the name
+          // used when the SDK is registered in addBspFetchedJdks → addJdkIfNeeded.
+          projectDetails.defaultJdkName = project.bazelProjectName.projectNameToJdkName(SdkUtils.resolveJavaHome(it.first()))
         } else {
           projectDetails.defaultJdkName = SdkUtils.getProjectJdkOrMostRecentJdk(project)?.name
         }

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/jvm/sync/SdkUtils.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/jvm/sync/SdkUtils.kt
@@ -27,12 +27,22 @@ internal object SdkUtils {
     // points to a directory containing only bin/java (a shell script), not a full JDK.
     // In that case, parse the wrapper to find the real JDK path.
     val resolvedHome = resolveJavaHome(javaHome)
-    val jdkName = projectName.projectNameToJdkName(resolvedHome)
+    val resolvedJdkName = projectName.projectNameToJdkName(resolvedHome)
     // Normalize the JDK path, because some code in the platform compares paths using `startsWith`, e.g.
     // https://github.com/JetBrains/intellij-community/blob/b41a4084da5521effedd334e28896fd9d07410da/java/codeserver/core/src/com/intellij/java/codeserver/core/JpmsModuleAccessInfo.kt#L216
     val path = resolvedHome.normalize().toString()
-    val jdk = ExternalSystemJdkProvider.getInstance().createJdk(jdkName, path)
+    val jdk = ExternalSystemJdkProvider.getInstance().createJdk(resolvedJdkName, path)
     addSdkIfNeeded(jdk)
+
+    // Module entities (via ModuleDetailsToJavaModuleTransformer) compute their SDK name from the
+    // raw javaHome (wrapper path), while addJdkIfNeeded registers under the resolved path name.
+    // To bridge this gap, also register an alias SDK under the original wrapper-path name so that
+    // module-level SDK dependencies can resolve and code does not show red.
+    if (resolvedHome != javaHome) {
+      val originalJdkName = projectName.projectNameToJdkName(javaHome)
+      val aliasJdk = ExternalSystemJdkProvider.getInstance().createJdk(originalJdkName, path)
+      addSdkIfNeeded(aliasJdk)
+    }
   }
 
   /**
@@ -40,8 +50,11 @@ internal object SdkUtils {
    * Otherwise, attempts to resolve the real JDK through multiple strategies:
    * 1. Parse the wrapper script at `{javaHome}/bin/java` for exec paths
    * 2. Scan `external/` under the Bazel exec root for a matching JDK
+   *
+   * Internal so callers that need to compute a stable SDK name (e.g. for [setProjectSdk]) can
+   * resolve the path through the same logic used by [addJdkIfNeeded].
    */
-  private fun resolveJavaHome(javaHome: Path): Path {
+  internal fun resolveJavaHome(javaHome: Path): Path {
     if (javaSdkInstance.isValidSdkHome(javaHome.normalize().toString())) {
       return javaHome
     }


### PR DESCRIPTION
## Summary

Regression from PR #31: after syncing a project that uses `jvm_wrapper_runtime`, two things break:
1. IntelliJ shows **"project SDK not configured"**
2. **All target modules show red code** due to unresolved module SDK dependency

## Root cause

`ModuleDetailsToJavaModuleTransformer` and `CollectProjectDetailsTask` both compute their SDK names by hashing the raw `javaHome` (the JVM wrapper path). After PR #31, `addJdkIfNeeded()` resolves the wrapper to the real JDK and registers the SDK under the **resolved path's** hash. The raw-path hash used by lookups is never registered, so:
- `setProjectSdk()` can't find the SDK → "project SDK not configured"
- module `SdkDependency` references can't resolve → red code

## Fix

- `SdkUtils.resolveJavaHome()` widened from `private` to `internal`
- **`CollectProjectDetailsTask`**: compute `defaultJdkName` from `SdkUtils.resolveJavaHome(it.first())` so the project-level lookup uses the resolved path hash — fixes regression #1
- **`SdkUtils.addJdkIfNeeded`**: when the wrapper path resolves to a different real JDK, also register an alias SDK under the **original wrapper-path name** pointing to the same real JDK home — fixes regression #2 (module-level)

## Test plan

- [ ] Open a project using `jvm_wrapper_runtime`, sync, verify:
  - No "project SDK not configured" banner
  - Target modules have no red code
- [ ] Verify on a project with a normal (non-wrapper) JDK that behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)