### PR TITLE
Eliminate shard modules; register umbrella as directory source root

### DIFF
--- a/CONTEXT_DEVELOPMENT_261.md
+++ b/CONTEXT_DEVELOPMENT_261.md
@@ -8,39 +8,34 @@
 > merges. Don't write "get PR reviewed/merged" — this doc lives in the repo and is read post-merge,
 > so those entries are immediately stale. Use `—` or omit the field when nothing remains.
 
-## Current State (as of 2026-08-12)
+## Current State (as of 2026-08-18)
 
 ### Working Branch
-`development-261` — latest tip: `669b674a0b Merge pull request #32`
+`feat/shard-module-elimination` — latest tip: `56c4d45337 feat: eliminate shard modules; register umbrella as directory source root`
 
-### Recently Completed Work (PR #31)
+### Recently Completed Work (PR #33)
 
-**Branch**: `fix/resolve-jvm-wrapper-jdk-home` → merged into `development-261`
+**Branch**: `fix/jvm-wrapper-project-sdk` → merged into `development-261`
 
-**Problem**: When a project uses `jvm_wrapper_runtime`, the `java_home` from the Bazel aspect points to the wrapper directory (contains only `bin/java` as a shell script), not the actual JDK. IntelliJ's `JavaSdk.isValidSdkHome()` fails → "JDK not found on disk or corrupted" warning after sync.
+**Problem**: PR #31 introduced two regressions with `jvm_wrapper_runtime` JDK resolution:
+1. Project SDK reported as "not configured" — `defaultJdkName` derived from raw wrapper path but SDK registered under resolved path.
+2. Target modules showed red code — `ModuleDetailsToJavaModuleTransformer` looked up the raw-path SDK name which no longer existed.
 
-**Fix** (`SdkUtils.kt`): `addJdkIfNeeded()` now calls `resolveJavaHome()` before creating the SDK. `resolveJavaHome()` tries two strategies: (1) parse `bin/java` wrapper script for `exec .../bin/java` lines and resolve against Bazel exec root; (2) scan `execroot/_main/external/` for JDK directories.
-
-### Recently Completed Work (PR #32)
-
-**Branch**: `feat/non-bazel-python-directories` → merged into `development-261`
-
-**Problem**: Python files not covered by any Bazel target inherit the Java SDK → no Python code intelligence.
-
-**Fix**: New `.bazelproject` section `non_bazel_python_directories:` — explicitly list directories. The plugin creates one IntelliJ module per listed directory with a Python SDK. Bazel-covered directories are skipped to avoid duplicate modules.
+**Fix**: `SdkUtils.resolveJavaHome()` widened to `internal`; `defaultJdkName` derived from resolved path; alias SDK registered under original wrapper-path name.
 
 ### Pending / In-Progress Work
 
-**JVM wrapper project SDK regression** — branch `fix/jvm-wrapper-project-sdk`, PR #33 open (→ `development-261`).
+**Shard module elimination** — branch `feat/shard-module-elimination`, PR #34 open (→ `development-261`).
 
-**Problem**: PR #31 introduced two regressions:
-1. The project SDK is reported as "not configured" — `defaultJdkName` hashed the raw wrapper path but the SDK was registered under the resolved path; the names diverged so `setProjectSdk` couldn't find it.
-2. Target modules showed red code — `ModuleDetailsToJavaModuleTransformer` computes `jvmJdkName` from the raw wrapper path, but after PR #31 only the resolved-path SDK was registered, so the module SDK dependency resolved to a non-existent SDK.
+**Problem**: `java_incremental_library` splits a target into one umbrella + N shard sub-targets. Importing shards as separate IntelliJ modules caused red code and bloated the module list.
 
-**Fix** (on `fix/jvm-wrapper-project-sdk`):
-- `SdkUtils.resolveJavaHome()` widened from `private` to `internal`
-- `CollectProjectDetailsTask.kt`: `defaultJdkName` now derived from `SdkUtils.resolveJavaHome(it.first())` (resolved path) — fixes regression #1
-- `SdkUtils.addJdkIfNeeded()`: when `resolvedHome != javaHome`, also registers an alias SDK under the original wrapper-path name pointing to the same real JDK — fixes regression #2
+**Fix** (`AspectBazelProjectMapper.kt`, `UnsyncedTargetUpdater.kt`): Shard-tagged targets filtered before partition into workspace/non-workspace; shard deps dropped from umbrella dependency lists; `resolveShardFolkDependencies` removed; `UnsyncedTargetUpdater` skips shard-tagged targets like `no-ide`.
+
+**File event batch guard** — branch `feat/file-event-batch-guard`, PR #35 open (→ `development-261`).
+
+**Problem**: A `git pull` can deliver dozens of `Create`/`ExternalCreate` events simultaneously, triggering an expensive Bazel inverse-sources query that chokes IntelliJ.
+
+**Fix** (`BazelFileEventListener.kt`): Early-exit sequence counts new-file events; if count exceeds `NEW_FILE_EVENTS_LIMIT` (5), skip processing and show Resync notification instead.
 
 **Next step**: —
 

--- a/intellij.bazel.importer/src/org/jetbrains/bazel/sync/workspace/mapper/normal/AspectBazelProjectMapper.kt
+++ b/intellij.bazel.importer/src/org/jetbrains/bazel/sync/workspace/mapper/normal/AspectBazelProjectMapper.kt
@@ -124,9 +124,9 @@ internal class AspectBazelProjectMapper(
               },
             )
         val (targetsToImport, nonWorkspaceTargets) =
-          targetsAtDepth.targets.partition {
-            isWorkspaceTarget(it, repoMapping, featureFlags, workspaceContext)
-          }
+          targetsAtDepth.targets
+            .filterNot { it.tagsList.contains("shard") }
+            .partition { isWorkspaceTarget(it, repoMapping, featureFlags, workspaceContext) }
         val (jvmDirectDependencies, nonJvmDirectDependencies) = targetsAtDepth.directDependencies.partition { it.getJvmTarget() }
         val jvmLibraries = (nonWorkspaceTargets + jvmDirectDependencies).associateBy { it.label() }
         (targetsToImport + nonJvmDirectDependencies).asSequence() to jvmLibraries
@@ -888,8 +888,7 @@ internal class AspectBazelProjectMapper(
     val resolvedDependencies = resolveDirectDependencies(target, dependencyGraph)
     // https://youtrack.jetbrains.com/issue/BAZEL-983: extra libraries can override some library versions, so they should be put before
     val (extraLibraries, lowPriorityExtraLibraries) = targetData.extraLibraries.partition { !it.isLowPriority }
-    val shardFolkDependencies: List<DependencyLabel> = resolveShardFolkDependencies(target, dependencyGraph).map { DependencyLabel(it) }
-    val directDependencies = extraLibraries.toDependencyLabels() + resolvedDependencies + lowPriorityExtraLibraries.toDependencyLabels() + shardFolkDependencies
+    val directDependencies = extraLibraries.toDependencyLabels() + resolvedDependencies + lowPriorityExtraLibraries.toDependencyLabels()
     val baseDirectory = bazelPathsResolver.toDirectoryPath(label, repoMapping)
     val languagePlugin = languagePluginsService.getLanguagePlugin(targetData.languages) ?: return null
     val resources = resolveResources(target, languagePlugin, localRepositories)
@@ -916,19 +915,14 @@ internal class AspectBazelProjectMapper(
 
   private fun resolveDirectDependencies(target: TargetInfo, dependencyGraph: DependencyGraph): List<DependencyLabel> {
     if (!target.tagsList.contains("umbrella")) return target.depsList.map { it.toDependencyLabel() }
-    // Umbrella targets (java_incremental_library) place their shard targets in runtime_deps so
-    // they arrive here with isRuntime=true. Promote them to compile-time so IntelliJ can resolve
-    // symbols across shards without red code.
-    return target.depsList.map { dep ->
-      val depLabel = dep.toDependencyLabel()
-      if (depLabel.isRuntime &&
-        dependencyGraph.getTargetInfo(depLabel.label)?.tagsList?.contains("shard") == true
-      ) {
-        depLabel.copy(isRuntime = false)
-      } else {
-        depLabel
+    // Umbrella targets (java_incremental_library) have shards as runtime_deps. Shards are excluded
+    // from IntelliJ modules, so drop them from the dependency list to avoid unresolved references.
+    // Symbol resolution is provided by the headers compile-time dependency.
+    return target.depsList
+      .filter { dep ->
+        dependencyGraph.getTargetInfo(dep.label())?.tagsList?.contains("shard") != true
       }
-    }
+      .map { it.toDependencyLabel() }
   }
 
   private fun BspTargetInfo.Dependency.toDependencyLabel(): DependencyLabel =
@@ -940,23 +934,6 @@ internal class AspectBazelProjectMapper(
 
   private fun List<Library>.toDependencyLabels(): List<DependencyLabel> = this.map { DependencyLabel(it.label) }
 
-  private fun resolveShardFolkDependencies(target: TargetInfo, dependencyGraph: DependencyGraph): List<Label> {
-    if (!target.tagsList.contains("shard")) return emptyList()
-    val umbrellaTargets = dependencyGraph
-      .getSourcesFromReverseDependencies(target.label())
-      .filter{ it.tagsList.contains("umbrella") }
-    return umbrellaTargets
-      .flatMap { umbrellaTarget ->
-        // Include sources from umbrella targets that depend on this shard
-        umbrellaTarget.depsList.mapNotNull { dependency ->
-          dependencyGraph.getTargetInfo(dependency.label())
-        }
-          .filter { dependencyTargetInfo ->
-            dependencyTargetInfo.tagsList.contains("shard")
-          }
-          .map { it.label() }
-      }
-  }
 
   // TODO: this is a re-creation of `Language.allOfKind`. To be removed when this logic is merged with client-side
   private val languagesFromKinds: Map<String, Set<LanguageClass>> =

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/workspace/UnsyncedTargetUpdater.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/workspace/UnsyncedTargetUpdater.kt
@@ -62,7 +62,7 @@ class UnsyncedTargetUpdater {
         val rawAspectTarget = partialSyncResult.targets[label]
         if (rawAspectTarget != null) {
           val targetInfo = rawAspectTarget
-          if (targetInfo.tagsList.contains("no-ide")) {
+          if (targetInfo.tagsList.contains("no-ide") || targetInfo.tagsList.contains("shard")) {
             return null
           }
 
@@ -161,7 +161,7 @@ class UnsyncedTargetUpdater {
         val baseDirectory = project.rootDir.toNioPath()
         for (label in labels) {
           val targetInfo = partialSyncResult.targets[label] ?: continue
-          if (targetInfo.tagsList.contains("no-ide")) continue
+          if (targetInfo.tagsList.contains("no-ide") || targetInfo.tagsList.contains("shard")) continue
 
           val dependencies = mutableListOf<ModuleDependencyItem>()
           val languages = inferLanguages(targetInfo)


### PR DESCRIPTION
## Summary

- **Problem**: `java_incremental_library` targets create hundreds of shard `java_library` targets, each imported as a separate IntelliJ module with file-level source roots. Adding a new `.java` file triggers a slow `buildTargetInverseSources` Bazel query (can take 10s+) because the new file isn't covered by any existing source root.
- **Fix**: Stop importing shards as IntelliJ modules. Instead, the umbrella target (with its full `srcs` list exposed via new IDE-tooling-only attrs in `java_incremental_library.bzl`) is imported as a single module. The plugin's `mergeSourceRoots` feature collapses the source list into a directory-level root, so new files are pre-covered and no Bazel query is needed.
- **Requires a companion change** in `java_incremental_library`: add `srcs` and `deps` attrs to `umbrella` (IDE tooling only; neither attr is used in the rule implementation or affects compilation).

See `SHARD_ELIMINATION_SUMMARY.md` for full background and detailed explanation.

## Plugin changes

- **`AspectBazelProjectMapper.kt`**: filter shard-tagged targets from `targetsToImport`; update `resolveDirectDependencies` for umbrella targets to drop shard deps (symbol resolution provided by headers JAR); remove `resolveShardFolkDependencies` (no longer needed)
- **`UnsyncedTargetUpdater.kt`**: skip shard-tagged targets in both single and batch partial-sync paths to prevent dynamic shard module creation in edge cases

## `java_incremental_library.bzl` changes (companion PR needed)

```python
# Add to _merge_compile_jar_and_runtime_deps rule attrs:
"srcs": attr.label_list(allow_files = True),  # IDE tooling only
"deps": attr.label_list(),                     # IDE tooling only

# Update call site:
_merge_compile_jar_and_runtime_deps(
    name = name,
    compile_dep = headers,
    srcs = srcs,        # new
    deps = [deps_lib],  # new
    runtime_deps = runtime_deps + src_names,
    tags = tags + ["umbrella"],
    visibility = visibility,
)
```

## Test plan

- [x] Sync a project containing umbrella & shard target
- [x] Verify the target appears as a single module (not hundreds of shard modules)
- [x] Add a new `.java` file in that module's directory — confirm IntelliJ does not trigger a Bazel query
- [x] Verify red code does not appear (symbol resolution working via headers JAR + `deps_lib`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)