### PR TITLE
fix: partial sync destroying target cache and hash mismatch in addTar…

### DIFF
--- a/intellij.bazel.commons/src/org/jetbrains/bazel/sync/environment/BazelTargetPersistenceLayer.kt
+++ b/intellij.bazel.commons/src/org/jetbrains/bazel/sync/environment/BazelTargetPersistenceLayer.kt
@@ -13,6 +13,14 @@ import java.nio.file.Path
 @ApiStatus.Internal
 interface BazelTargetPersistenceLayer {
   suspend fun saveAll(project: Project, spec: TargetPersistenceSpec)
+
+  /**
+   * Merges the given partial sync targets into the existing cache without clearing it.
+   * Used during partial project sync to avoid wiping target data for the rest of the project.
+   * Defaults to a full saveAll for implementations that don't support partial merge.
+   */
+  suspend fun mergePartial(project: Project, spec: TargetPersistenceSpec): Unit = saveAll(project, spec)
+
   suspend fun notifyAll(project: Project)
 }
 

--- a/intellij.bazel.importer/src/org/jetbrains/bazel/sync/hooks/TargetPersistenceLayerSyncHook.kt
+++ b/intellij.bazel.importer/src/org/jetbrains/bazel/sync/hooks/TargetPersistenceLayerSyncHook.kt
@@ -3,6 +3,7 @@ package org.jetbrains.bazel.sync.hooks
 import org.jetbrains.bazel.sync.ProjectSyncHook
 import org.jetbrains.bazel.sync.environment.TargetPersistenceSpec
 import org.jetbrains.bazel.sync.environment.projectCtx
+import org.jetbrains.bazel.sync.scope.PartialProjectSync
 
 // TODO: rename
 internal class TargetPersistenceLayerSyncHook : ProjectSyncHook {
@@ -15,7 +16,11 @@ internal class TargetPersistenceLayerSyncHook : ProjectSyncHook {
         libraryItems = workspace.libraries,
         file2Target = workspace.fileToTarget,
     )
-    targetPersistanceLayer.saveAll(project, spec)
+    if (environment.syncScope is PartialProjectSync) {
+      targetPersistanceLayer.mergePartial(project, spec)
+    } else {
+      targetPersistanceLayer.saveAll(project, spec)
+    }
     targetPersistanceLayer.notifyAll(project)
   }
 }

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/target/TargetUtils.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/target/TargetUtils.kt
@@ -183,6 +183,21 @@ class TargetUtils(private val project: Project, private val coroutineScope: Coro
     notifyTargetListUpdated()
   }
 
+  /**
+   * Merges partial sync targets into the cache without clearing existing entries.
+   * Updates labelToTargetInfo, moduleIdToTarget, and fileToTargets for the given targets
+   * while preserving all other project targets in the cache.
+   */
+  fun mergePartialTargets(targets: List<RawBuildTarget>, fileToTarget: Map<Path, List<Label>>) {
+    ThreadingAssertions.assertBackgroundThread()
+    val labelToTargetInfo = targets.associateBy { it.id }
+    db.addTargets(labelToTargetInfo, project)
+    for ((path, labels) in fileToTarget) {
+      db.addFileToTarget(path, labels)
+    }
+    notifyTargetListUpdated()
+  }
+
   // todo expensive operation
   fun computeFullLabelToTargetInfoMap(syncedTargetIdToTargetInfo: Map<Label, BuildTarget>): Map<Label, BuildTarget> =
     db.computeFullLabelToTargetInfoMap(syncedTargetIdToTargetInfo)

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/target/TargetsCacheStorage.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/target/TargetsCacheStorage.kt
@@ -207,7 +207,7 @@ class TargetsCacheStorage(
   }
 
   fun addTargets(labelToTargetInfo: Map<Label, BuildTarget>, project: Project) {
-    val hashStream = Hashing.xxh3_128()
+    val hashStream = Hashing.xxh3_64()
       .hashStream()
     for ((label, info) in labelToTargetInfo) {
       // must be canonical label

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/target/sync/TargetUtilsTargetPersistanceLayer.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/target/sync/TargetUtilsTargetPersistanceLayer.kt
@@ -18,6 +18,16 @@ internal class TargetUtilsTargetPersistanceLayer : BazelTargetPersistenceLayer {
     )
   }
 
+  override suspend fun mergePartial(
+    project: Project,
+    spec: TargetPersistenceSpec,
+  ) {
+    project.targetUtils.mergePartialTargets(
+      targets = spec.targets,
+      fileToTarget = spec.file2Target,
+    )
+  }
+
   override suspend fun notifyAll(project: Project) {
     project.targetUtils.notifyTargetListUpdated()
   }

--- a/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/workspace/fileEvents/BazelFileEventListener.kt
+++ b/plugin-bazel/src/main/kotlin/org/jetbrains/bazel/workspace/fileEvents/BazelFileEventListener.kt
@@ -290,7 +290,9 @@ class BazelFileEventListener : BulkFileListenerBackgroundable {
     val modulesAlreadyContainingFiles =
       applicableEvents.associateNewFilePathsWithExistingModules(existingModulesByEvent)
     val addedFilePaths = applicableEvents.mapNotNull { it.fileAdded }
+    val hasExternalCreateEvents = applicableEvents.any { it is SimplifiedFileEvent.ExternalCreate }
     val bazelQueryIsRequired =
+      hasExternalCreateEvents ||
       addedFilePaths.any {
         modulesToRemoveFilesFrom[it]?.isNotEmpty() == true || modulesAlreadyContainingFiles[it].isNullOrEmpty()
       }


### PR DESCRIPTION
…gets

Three fixes for partial sync:

1. TargetPersistenceLayerSyncHook: route PartialProjectSync through new mergePartial() path that additively updates the target cache instead of calling reset() which wiped all existing targets.

2. TargetsCacheStorage.addTargets(): use xxh3_64 (matching reset() and addFileToTarget()) instead of xxh3_128. The mismatch meant getTargetsForPath() could never resolve labels added via addTargets(), breaking gutter icons and file-to-target lookups after partial sync.

3. BazelFileEventListener: force Bazel query for ExternalCreate events (files submitted by external plugins like Snowjet) even when the file appears to be in an existing module's source root. Without this, new targets created alongside new files were never discovered.